### PR TITLE
Untitled

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-tar "1.0.2"
+(defproject lein-tar "1.0.3"
   :description "Create a tarball of your Leiningen projects."
   :eval-in-leiningen true
   :min-lein-version "1.4.0")

--- a/src/leiningen/tar.clj
+++ b/src/leiningen/tar.clj
@@ -24,13 +24,19 @@
       (.write tar (.toByteArray baos))
       (.closeEntry tar))))
 
+(defn build-info [project]
+  (if-let [build-info (:build-info project)]
+    build-info
+    (when (System/getenv "BUILD_ID")
+      {:build-id (System/getenv "BUILD_ID")
+       :build-tag (System/getenv "BUILD_TAG")})))
+
 (defn- add-build-info [project]
-  (when (System/getenv "BUILD_ID")
-    (let [build-file (file (:root project) "pkg" "build.clj")]
+  (let [build-file (file (:root project) "pkg" "build.clj")
+        build-info (build-info project)]
+    (when build-info
       (.deleteOnExit build-file)
-      (spit build-file
-            (str {:build-id (System/getenv "BUILD_ID")
-                  :build-tag (System/getenv "BUILD_TAG")} "\n")))))
+      (spit build-file (str build-info "\n")))))
 
 (defn tar [project]
   (add-build-info project)

--- a/test/leiningen/test_release.clj
+++ b/test/leiningen/test_release.clj
@@ -1,6 +1,0 @@
-(ns lein-release.core-test
-  (:use [lein-release.core] :reload-all)
-  (:use [clojure.test]))
-
-(deftest replace-me ;; FIXME: write
-  (is false))


### PR DESCRIPTION
make build-info an overridable function, so that, for instance, a project could elect to insert the git sha of the current commit
