### PR TITLE
Don't include target/ directory element on output tar

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Add `:tar {:uberjar true}` to your project.clj.
 
 Use option `:format` to specify the desired output format: either a `tar` (default) or a `tgz` (tar + gzip). Example: `:tar {:format :tgz}`.
 
+
+## Breaking changes since version 2.0.0
+
+Starting with version 3.0.0, we introduced the following breaking changes:
+
+* The plugin adds the `.jar` files to the resulting archive under `lib/` instead of `lib/target`
+* By default, the plugin now generates the resulting archive in the projects' target directory (that is, the `:target-path` of the project), instead of the project's root. You can change this with the new option `:output-dir`.
+
+
 ## Known Issues
 
 Due to absurd limitations in the Java file API, Unix permissions

--- a/src/leiningen/tar.clj
+++ b/src/leiningen/tar.clj
@@ -97,10 +97,12 @@
   (add-build-info project)
   (let [options (:tar project)
         fmt (or (keyword (:format options)) :tar)
+        output-dir (or (:output-dir options) (:target-path project))
         release-name (release-name project)
-        tar-file (io/file (:root project) (format "%s.%s" release-name (name fmt))) ]
+        tar-file (io/file output-dir (format "%s.%s" release-name (name fmt))) ]
 
     (.delete tar-file)
+    (.mkdirs (.getParentFile tar-file))
     (with-open [tar (TarOutputStream. (case fmt
                                         :tgz (GZIPOutputStream.
                                               (FileOutputStream. tar-file))

--- a/src/leiningen/tar.clj
+++ b/src/leiningen/tar.clj
@@ -18,12 +18,12 @@
 
 (defn entry-name [release-name f]
   (let [f (unix-path f)
-        prefix (unix-path (str (System/getProperty "user.dir") "/(pkg)?/?"))
+        prefix (unix-path (str (System/getProperty "user.dir") "/(pkg|target)?/?"))
         stripped (.replaceAll f prefix "")]
     (str release-name "/"
          (if (.startsWith f (unix-path (str (System/getProperty "user.home")
                                             "/.m2")))
-           (str "lib/target/" (last (.split f "/")))
+           (str "lib/" (last (.split f "/")))
            stripped))))
 
 (defn- add-file [release-name tar f]


### PR DESCRIPTION
I see that the generated archive contained all jar files under a `lib/target/` directory.

I think it'd be better to chop 'target/' off, so the jar files end up under `lib/`. This is my intention with this patch.

Now, this might break some people's existing scripts... So, if you agree on accepting this change, we'd have to bump the minor version number and add a notice about this change on the README.

Thanks!
