### PR TITLE
+ Possibility to specify :tar-gz for getting a .tar.gz suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add `:tar {:uberjar true}` to your project.clj.
 
 ## Output format
 
-Use option `:format` to specify the desired output format: either a `tar` (default) or a `tgz` (tar + gzip). Example: `:tar {:format :tgz}`.
+Use option `:format` to specify the desired output format: either a `tar` (default) or a `tgz`/`tar-gz` (tar + gzip). Example: `:tar {:format :tgz}`.
 
 
 ## Breaking changes since version 2.0.0

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-tar "3.0.0"
+(defproject lein-tar "3.1.0"
   :url "https://github.com/technomancy/lein-tar"
   :license "Eclipse Public License 1.0"
   :description "Create a tarball of your Leiningen projects."


### PR DESCRIPTION
I need to create .tar.gz files for arch packages, and think it might not hurt to contribute this back.

It's a completely nonbreaking change. I tested it manually and locally.
Maybe you should do so as well to convince yourself that it's working.

Thanks for the plugin, btw!
