### PR TITLE
Update README installation section with latest released version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Formerly known as lein-release.
 
 ### With Leiningen 2
 
-Add [lein-tar "2.0.0"] to your project's `:plugins`.
+Add [lein-tar "3.2.0"] to your project's `:plugins`.
 
 ### With Leiningen 1
 


### PR DESCRIPTION
The README version is still 2.0.0 and copy/pasting the install instructions caused me all kinds of headaches until I realized I was using an old version.

Here's hoping this PR can save others a few gray hairs. ;)
