### PR TITLE
Add option for removing the leading path element. 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-tar "3.2.0"
+(defproject lein-tar "3.2.1-SNAPSHOT"
   :url "https://github.com/technomancy/lein-tar"
   :license "Eclipse Public License 1.0"
   :description "Create a tarball of your Leiningen projects."

--- a/src/leiningen/tar.clj
+++ b/src/leiningen/tar.clj
@@ -141,4 +141,4 @@
       (if (:uberjar options)
         (add-uberjar project tar-name tar options)
         (add-jars project tar-name tar options))
-      (println "Wrote" (.getName tar-file)))))
+      (println "Wrote" (.getAbsolutePath tar-file)))))


### PR DESCRIPTION
Adds `:strip-leading-path` to the `:tar` options hashmap.
If `:strip-leading-path` is set to true, then the leading directory path
element (in this plugin's case the project name) will be stripped.

This gives the same result as running the folowing in the command line:
`tar czf lein-tar-3.2.0.tgz -C lein-tar-3.2.0/ .`

Example tar archive contents for values of `:strip-leading-path`:

| false (default) | true |
| --- | --- |
| lein-tar-3.2.0/ |  |
| lein-tar-3.2.0/bin | bin/ |
| lein-tar-3.2.0/bin/heyo | bin/heyo |
| lein-tar-3.2.0/etc | etc/ |
| lein-tar-3.2.0/etc/foo.conf | etc/foo.conf |
| lein-tar-3.2.0/lib/ | lib/ |
| lein-tar-3.2.0/lib/lein-tar-3.2.0.jar | lib/lein-tar-3.2.0.jar |
