### PR TITLE
Fix semi-relative paths in file

### DIFF
--- a/src/leiningen/tar.clj
+++ b/src/leiningen/tar.clj
@@ -17,7 +17,7 @@
   "Converts a File or String into a unix-like path"
   [f]
   (-> (if (instance? java.io.File f)
-        (.getAbsolutePath f)
+        (.getCanonicalPath f)
         f)
       (.replaceAll "\\\\" "/"))) ; WINDERS!!!!
 


### PR DESCRIPTION
Use .getCannonicalPath instead of .getAbsolutePath
Fixes https://github.com/technomancy/lein-tar/issues/17
